### PR TITLE
Changing to Opaque, Premultiplied doesn't exist for metal I think

### DIFF
--- a/app-surface/src/ios.rs
+++ b/app-surface/src/ios.rs
@@ -44,7 +44,7 @@ impl AppSurface {
             width: physical.0,
             height: physical.1,
             present_mode: wgpu::PresentMode::Fifo,
-            alpha_mode: wgpu::CompositeAlphaMode::PreMultiplied,
+            alpha_mode: wgpu::CompositeAlphaMode::Opaque,
         };
         surface.configure(&device, &config);
         AppSurface {


### PR DESCRIPTION
this was crashing when I tried to run it for the first time.  Simple change.  Thanks for making this repo.